### PR TITLE
feat(git): clone git repositories without blobs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -265,6 +265,8 @@ fn main() -> Result<()> {
             println!("Cloning {}", repository);
             let out = Command::new("git")
                 .arg("clone")
+                .arg("--filter=blob:none")
+                .arg("--")
                 .arg(repository.to_string())
                 .arg(&repo_dir)
                 .output()?;


### PR DESCRIPTION
Using `--filter=blob:none` still clones tags,
but avoids downloading blobs until they are needed,
e.g. until particular revision of the repository is checked out.

Cloning all blobs including large deleted files
may take a lot of space for some repositories.
