### PR TITLE
Show dependency status of main branch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Crates.io Version](https://img.shields.io/crates/v/cargo-goggles)](https://crates.io/crates/cargo-goggles)
 ![Crates.io License](https://img.shields.io/crates/l/cargo-goggles)
 [![CI](https://github.com/M4SS-Code/cargo-goggles/workflows/CI/badge.svg)](https://github.com/M4SS-Code/cargo-goggles/actions)
-[![dependency status](https://deps.rs/crate/cargo-goggles/0.0.1/status.svg)](https://deps.rs/crate/cargo-goggles/0.0.1)
+[![dependency status](https://deps.rs/repo/github/M4SS-Code/cargo-goggles/status.svg)](https://deps.rs/repo/github/M4SS-Code/cargo-goggles)
 
 Verify that registry crates in your Cargo.lock are reproducible from the git repository.
 


### PR DESCRIPTION
It is a bit misleading to show the status of the last published version, because some issues could have been already resolved and this is not clear at a first glance.

Feel free to close this PR if the current behavior is intended.